### PR TITLE
Adding Secondary GPS Data Information in MAVSDK

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,7 +98,7 @@ jobs:
   ubuntu20-proto-check:
     name: ubuntu-20.04 (proto check)
     runs-on: ubuntu-20.04
-    if: never()  # turning off - not relevant for our use (Dominik/William)
+    if: false  # turning off - not relevant for our use (Dominik/William)
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,6 +144,7 @@ jobs:
   deb-package:
     name: ${{ matrix.container_name }} (package, non-mavsdk_server)
     runs-on: ubuntu-18.04
+    if: false  # turning off - not relevant for our use (Dominik/William)    
     container: mavsdk/mavsdk-${{ matrix.container_name }}
     strategy:
       matrix:
@@ -172,7 +173,6 @@ jobs:
   debian-packaging:
     name: Ubuntu/Debian packaging (Ubuntu 20.04)
     runs-on: ubuntu-20.04
-    if: false  # turning off - not relevant for our use (Dominik/William)
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -172,6 +172,7 @@ jobs:
   debian-packaging:
     name: Ubuntu/Debian packaging (Ubuntu 20.04)
     runs-on: ubuntu-20.04
+    if: false  # turning off - not relevant for our use (Dominik/William)
     steps:
       - uses: actions/checkout@v2
         with:
@@ -491,6 +492,7 @@ jobs:
   Windows:
     name: Windows
     runs-on: windows-latest
+    if: false  # turning off - not relevant for our use (Dominik/William)    
     steps:
       - uses: actions/checkout@v2
         with:
@@ -538,6 +540,7 @@ jobs:
   px4-sitl-older:
     name: PX4 SITL ${{ matrix.px4_version }} (ubuntu-18.04)
     runs-on: ubuntu-18.04
+    if: false  # turning off - not relevant for our use (Dominik/William)    
     container: mavsdk/mavsdk-ubuntu-18.04-px4-sitl-${{ matrix.px4_version }}
     strategy:
       matrix:
@@ -552,6 +555,7 @@ jobs:
   px4-sitl-newer:
     name: PX4 SITL ${{ matrix.px4_version }} (ubuntu-20.04)
     runs-on: ubuntu-18.04
+    if: false  # turning off - not relevant for our use (Dominik/William)    
     container: mavsdk/mavsdk-ubuntu-20.04-px4-sitl-${{ matrix.px4_version }}
     strategy:
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,6 +98,7 @@ jobs:
   ubuntu20-proto-check:
     name: ubuntu-20.04 (proto check)
     runs-on: ubuntu-20.04
+    if: never()  # turning off - not relevant for our use (Dominik/William)
     steps:
       - uses: actions/checkout@v2
         with:

--- a/src/mavsdk_server/src/plugins/offboard/offboard_service_impl.h
+++ b/src/mavsdk_server/src/plugins/offboard/offboard_service_impl.h
@@ -434,7 +434,8 @@ public:
             return grpc::Status::OK;
         }
 
-        auto result = _lazy_plugin.maybe_plugin()->set_attitude_once(translateFromRpcAttitude(request->attitude()));
+        auto result = _lazy_plugin.maybe_plugin()->set_attitude_once(
+            translateFromRpcAttitude(request->attitude()));
 
         if (response != nullptr) {
             fillResponseWithResult(response, result);
@@ -491,7 +492,8 @@ public:
             return grpc::Status::OK;
         }
 
-        auto result = _lazy_plugin.maybe_plugin()->set_actuator_control_once(translateFromRpcActuatorControl(request->actuator_control()));
+        auto result = _lazy_plugin.maybe_plugin()->set_actuator_control_once(
+            translateFromRpcActuatorControl(request->actuator_control()));
 
         if (response != nullptr) {
             fillResponseWithResult(response, result);
@@ -548,7 +550,8 @@ public:
             return grpc::Status::OK;
         }
 
-        auto result = _lazy_plugin.maybe_plugin()->set_attitude_rate_once(translateFromRpcAttitudeRate(request->attitude_rate()));
+        auto result = _lazy_plugin.maybe_plugin()->set_attitude_rate_once(
+            translateFromRpcAttitudeRate(request->attitude_rate()));
 
         if (response != nullptr) {
             fillResponseWithResult(response, result);
@@ -605,7 +608,8 @@ public:
             return grpc::Status::OK;
         }
 
-        auto result = _lazy_plugin.maybe_plugin()->set_position_ned_once(translateFromRpcPositionNedYaw(request->position_ned_yaw()));
+        auto result = _lazy_plugin.maybe_plugin()->set_position_ned_once(
+            translateFromRpcPositionNedYaw(request->position_ned_yaw()));
 
         if (response != nullptr) {
             fillResponseWithResult(response, result);
@@ -662,8 +666,9 @@ public:
             return grpc::Status::OK;
         }
 
-        auto result = _lazy_plugin.maybe_plugin()->set_velocity_body_once(translateFromRpcVelocityBodyYawspeed(request->velocity_body_yawspeed()));
-        
+        auto result = _lazy_plugin.maybe_plugin()->set_velocity_body_once(
+            translateFromRpcVelocityBodyYawspeed(request->velocity_body_yawspeed()));
+
         if (response != nullptr) {
             fillResponseWithResult(response, result);
         }

--- a/src/mavsdk_server/src/plugins/telemetry/telemetry_service_impl.h
+++ b/src/mavsdk_server/src/plugins/telemetry/telemetry_service_impl.h
@@ -483,7 +483,7 @@ public:
     }
 
     static std::unique_ptr<rpc::telemetry::GpsRtcmData>
-    translateToRpcGpsRtcmData(const mavsdk::Telemetry::GpsRtcmData &gps_rtcm_data)
+    translateToRpcGpsRtcmData(const mavsdk::Telemetry::GpsRtcmData& gps_rtcm_data)
     {
         auto rpc_obj = std::make_unique<rpc::telemetry::GpsRtcmData>();
 
@@ -498,7 +498,8 @@ public:
         return rpc_obj;
     }
 
-    static mavsdk::Telemetry::GpsRtcmData translateFromRpcGpsRtcmData(const rpc::telemetry::GpsRtcmData& gps_rtcm_data)
+    static mavsdk::Telemetry::GpsRtcmData
+    translateFromRpcGpsRtcmData(const rpc::telemetry::GpsRtcmData& gps_rtcm_data)
     {
         mavsdk::Telemetry::GpsRtcmData obj;
 
@@ -608,9 +609,9 @@ public:
 
         auto custom_main_mode = uint8_t((mode_info.custom_mode >> 16U) & 0xffU);
         auto custom_sub_mode = uint8_t((mode_info.custom_mode >> 24U) & 0xffU);
-        
+
         rpc_obj->set_base_mode(mode_info.base_mode);
-    
+
         rpc_obj->set_custom_main_mode(custom_main_mode);
 
         rpc_obj->set_custom_sub_mode(custom_sub_mode);
@@ -1924,7 +1925,8 @@ public:
                 const mavsdk::Telemetry::GpsRtcmData gps_rtcm_data) {
                 rpc::telemetry::GpsRtcmDataResponse rpc_response;
 
-                rpc_response.set_allocated_gps_rtcm_data(translateToRpcGpsRtcmData(gps_rtcm_data).release());
+                rpc_response.set_allocated_gps_rtcm_data(
+                    translateToRpcGpsRtcmData(gps_rtcm_data).release());
 
                 std::unique_lock<std::mutex> lock(*subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
@@ -2004,7 +2006,8 @@ public:
                 const mavsdk::Telemetry::BatteryStatus battery_status) {
                 rpc::telemetry::BatteryStatusResponse rpc_response;
 
-                rpc_response.set_allocated_battery_status(translateToRpcBatteryStatus(battery_status).release());
+                rpc_response.set_allocated_battery_status(
+                    translateToRpcBatteryStatus(battery_status).release());
 
                 std::unique_lock<std::mutex> lock(*subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
@@ -2044,11 +2047,11 @@ public:
                 const mavsdk::Telemetry::VehicleStatus vehicle_status) {
                 rpc::telemetry::VehicleStatusResponse rpc_response;
 
-                rpc_response.set_allocated_vehicle_status(translateToRpcVehicleStatus(vehicle_status).release());
+                rpc_response.set_allocated_vehicle_status(
+                    translateToRpcVehicleStatus(vehicle_status).release());
 
                 std::unique_lock<std::mutex> lock(*subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {
-
                     _lazy_plugin.maybe_plugin()->subscribe_vehicle_status(nullptr);
 
                     *is_finished = true;
@@ -2123,20 +2126,19 @@ public:
         _lazy_plugin.maybe_plugin()->subscribe_mode_info(
             [this, &writer, &stream_closed_promise, is_finished, subscribe_mutex](
                 const mavsdk::Telemetry::ModeInfo mode_info) {
-            rpc::telemetry::ModeInfoResponse rpc_response;
+                rpc::telemetry::ModeInfoResponse rpc_response;
 
-            rpc_response.set_allocated_mode_info(translateToRpcModeInfo(mode_info).release());
+                rpc_response.set_allocated_mode_info(translateToRpcModeInfo(mode_info).release());
 
-            std::unique_lock<std::mutex> lock(*subscribe_mutex);
-            if (!*is_finished && !writer->Write(rpc_response)) {
+                std::unique_lock<std::mutex> lock(*subscribe_mutex);
+                if (!*is_finished && !writer->Write(rpc_response)) {
+                    _lazy_plugin.maybe_plugin()->subscribe_mode_info(nullptr);
 
-                _lazy_plugin.maybe_plugin()->subscribe_mode_info(nullptr);
-
-                *is_finished = true;
-                unregister_stream_stop_promise(stream_closed_promise);
-                stream_closed_promise->set_value();
-            }
-        });
+                    *is_finished = true;
+                    unregister_stream_stop_promise(stream_closed_promise);
+                    stream_closed_promise->set_value();
+                }
+            });
 
         stream_closed_future.wait();
         std::unique_lock<std::mutex> lock(*subscribe_mutex);
@@ -2369,7 +2371,8 @@ public:
                 const mavsdk::Telemetry::ServoOutputRaw servo_output_raw) {
                 rpc::telemetry::ServoOutputRawResponse rpc_response;
 
-                rpc_response.set_allocated_servo_output_raw(translateToRpcServoOutputRaw(servo_output_raw).release());
+                rpc_response.set_allocated_servo_output_raw(
+                    translateToRpcServoOutputRaw(servo_output_raw).release());
 
                 std::unique_lock<std::mutex> lock(*subscribe_mutex);
                 if (!*is_finished && !writer->Write(rpc_response)) {

--- a/src/plugins/log_files/include/plugins/log_files/log_files.h
+++ b/src/plugins/log_files/include/plugins/log_files/log_files.h
@@ -165,7 +165,7 @@ public:
      *
      * This function is non-blocking. See 'erase_all_log_files' for the blocking counterpart.
      */
-     void erase_all_log_files_async(const ResultCallback callback);
+    void erase_all_log_files_async(const ResultCallback callback);
 
     /**
      * @brief Erase all log files.

--- a/src/plugins/log_files/log_files_impl.cpp
+++ b/src/plugins/log_files/log_files_impl.cpp
@@ -301,7 +301,7 @@ LogFiles::Result LogFilesImpl::erase_all_log_files()
     auto prom = std::promise<LogFiles::Result>();
     auto fut = prom.get_future();
 
-    erase_all_log_files_async([&prom](LogFiles::Result result) { prom.set_value(result);});
+    erase_all_log_files_async([&prom](LogFiles::Result result) { prom.set_value(result); });
     return fut.get();
 }
 
@@ -314,9 +314,8 @@ void LogFilesImpl::erase_all_log_files_async(LogFiles::ResultCallback callback)
 
         if (callback) {
             const auto tmp_callback = callback;
-            _parent->call_user_callback([tmp_callback]() {
-                tmp_callback(LogFiles::Result::Success);
-            });
+            _parent->call_user_callback(
+                [tmp_callback]() { tmp_callback(LogFiles::Result::Success); });
         }
     }
 }
@@ -467,12 +466,11 @@ void LogFilesImpl::request_erase_all_logs()
 {
     mavlink_message_t msg;
     mavlink_msg_log_erase_pack(
-            _parent->get_own_system_id(),
-            _parent->get_own_component_id(),
-            &msg,
-            _parent->get_system_id(),
-            _parent->get_autopilot_id()
-            );
+        _parent->get_own_system_id(),
+        _parent->get_own_component_id(),
+        &msg,
+        _parent->get_system_id(),
+        _parent->get_autopilot_id());
     _parent->send_message(msg);
 }
 

--- a/src/plugins/offboard/include/plugins/offboard/offboard.h
+++ b/src/plugins/offboard/include/plugins/offboard/offboard.h
@@ -298,8 +298,9 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool
-    operator==(const Offboard::AccelerationBodyYawspeed& lhs, const Offboard::AccelerationBodyYawspeed& rhs);
+    friend bool operator==(
+        const Offboard::AccelerationBodyYawspeed& lhs,
+        const Offboard::AccelerationBodyYawspeed& rhs);
 
     /**
      * @brief Stream operator to print information about a `Offboard::AccelerationNed`.
@@ -535,9 +536,11 @@ public:
      *
      * @return Result of request.
      */
-    Result set_acceleration_body_yawspeed(AccelerationBodyYawspeed acceleration_body_yawspeed) const;
+    Result
+    set_acceleration_body_yawspeed(AccelerationBodyYawspeed acceleration_body_yawspeed) const;
 
-    Result set_acceleration_body_yawspeed_once(AccelerationBodyYawspeed acceleration_body_yawspeed) const;
+    Result
+    set_acceleration_body_yawspeed_once(AccelerationBodyYawspeed acceleration_body_yawspeed) const;
 
     /**
      * @brief Copy constructor.

--- a/src/plugins/offboard/include/plugins/offboard/offboard.h
+++ b/src/plugins/offboard/include/plugins/offboard/offboard.h
@@ -539,6 +539,14 @@ public:
     Result
     set_acceleration_body_yawspeed(AccelerationBodyYawspeed acceleration_body_yawspeed) const;
 
+    /**
+     * @brief Set the acceleration in body coordinates.
+     * Only send one request.
+     *
+     * This function is blocking.
+     *
+     * @return Result of request.
+     */
     Result
     set_acceleration_body_yawspeed_once(AccelerationBodyYawspeed acceleration_body_yawspeed) const;
 

--- a/src/plugins/offboard/mocks/offboard_mock.h
+++ b/src/plugins/offboard/mocks/offboard_mock.h
@@ -7,18 +7,24 @@ namespace testing {
 
 class MockOffboard {
 public:
+    MOCK_CONST_METHOD0(request_offboard, Offboard::Result()){};
     MOCK_CONST_METHOD0(start, Offboard::Result()){};
     MOCK_CONST_METHOD0(stop, Offboard::Result()){};
     MOCK_CONST_METHOD0(is_active, bool()){};
+    MOCK_CONST_METHOD1(set_attitude_once, Offboard::Result(Offboard::Attitude)){};
     MOCK_CONST_METHOD1(set_attitude, Offboard::Result(Offboard::Attitude)){};
+    MOCK_CONST_METHOD1(set_attitude_rate_once, Offboard::Result(Offboard::AttitudeRate)){};
     MOCK_CONST_METHOD1(set_attitude_rate, Offboard::Result(Offboard::AttitudeRate)){};
+    MOCK_CONST_METHOD1(set_position_ned_once, Offboard::Result(Offboard::PositionNedYaw)){};
     MOCK_CONST_METHOD1(set_position_ned, Offboard::Result(Offboard::PositionNedYaw)){};
+    MOCK_CONST_METHOD1(set_velocity_body_once, Offboard::Result(Offboard::VelocityBodyYawspeed));
     MOCK_CONST_METHOD1(set_velocity_body, Offboard::Result(Offboard::VelocityBodyYawspeed)){};
     MOCK_CONST_METHOD1(set_velocity_ned, Offboard::Result(Offboard::VelocityNedYaw)){};
     MOCK_CONST_METHOD2(
         set_position_velocity_ned,
         Offboard::Result(Offboard::PositionNedYaw, Offboard::VelocityNedYaw)){};
     MOCK_CONST_METHOD1(set_acceleration_ned, Offboard::Result(Offboard::AccelerationNed)){};
+    MOCK_CONST_METHOD1(set_actuator_control_once, Offboard::Result(Offboard::ActuatorControl)){};
     MOCK_CONST_METHOD1(set_actuator_control, Offboard::Result(Offboard::ActuatorControl)){};
 };
 

--- a/src/plugins/offboard/offboard.cpp
+++ b/src/plugins/offboard/offboard.cpp
@@ -317,7 +317,8 @@ std::ostream& operator<<(std::ostream& str, Offboard::AccelerationNed const& acc
     return str;
 }
 
-bool operator==(const Offboard::AccelerationBodyYawspeed& lhs, const Offboard::AccelerationBodyYawspeed& rhs)
+bool operator==(
+    const Offboard::AccelerationBodyYawspeed& lhs, const Offboard::AccelerationBodyYawspeed& rhs)
 {
     return ((std::isnan(rhs.forward_m_s2) && std::isnan(lhs.forward_m_s2)) ||
             rhs.forward_m_s2 == lhs.forward_m_s2) &&
@@ -329,7 +330,8 @@ bool operator==(const Offboard::AccelerationBodyYawspeed& lhs, const Offboard::A
             rhs.down_m_s2 == lhs.yaw_deg_s);
 }
 
-std::ostream& operator<<(std::ostream& str, Offboard::AccelerationBodyYawspeed const& acceleration_body)
+std::ostream&
+operator<<(std::ostream& str, Offboard::AccelerationBodyYawspeed const& acceleration_body)
 {
     str << std::setprecision(15);
     str << "acceleration_body_yawspeed:" << '\n' << "{\n";

--- a/src/plugins/offboard/offboard_impl.cpp
+++ b/src/plugins/offboard/offboard_impl.cpp
@@ -282,7 +282,9 @@ Offboard::Result OffboardImpl::set_acceleration_body_yawspeed(
             }
             // We automatically send Ned setpoints from now on.
             _parent->add_call_every(
-                [this]() { send_acceleration_body_yawspeed(); }, SEND_INTERVAL_S, &_call_every_cookie);
+                [this]() { send_acceleration_body_yawspeed(); },
+                SEND_INTERVAL_S,
+                &_call_every_cookie);
 
             _mode = Mode::AccelerationBodyYawspeed;
         } else {
@@ -654,7 +656,6 @@ Offboard::Result OffboardImpl::send_acceleration_ned()
                                             Offboard::Result::ConnectionError;
 }
 
-
 Offboard::Result OffboardImpl::send_acceleration_body_yawspeed()
 {
     const static uint16_t IGNORE_X = (1 << 0);
@@ -691,8 +692,8 @@ Offboard::Result OffboardImpl::send_acceleration_body_yawspeed()
         acceleration_body_yawspeed.down_m_s2,
         0.0f, // yaw
         to_rad_from_deg(acceleration_body_yawspeed.yaw_deg_s)); // yaw_rate
-        return _parent->send_message(message) ? Offboard::Result::Success :
-        Offboard::Result::ConnectionError;
+    return _parent->send_message(message) ? Offboard::Result::Success :
+                                            Offboard::Result::ConnectionError;
 }
 
 Offboard::Result OffboardImpl::send_velocity_body()

--- a/src/plugins/offboard/offboard_impl.h
+++ b/src/plugins/offboard/offboard_impl.h
@@ -39,8 +39,8 @@ public:
     Offboard::Result set_acceleration_ned(Offboard::AccelerationNed acceleration_ned);
     Offboard::Result
     set_acceleration_body_yawspeed(Offboard::AccelerationBodyYawspeed acceleration_ned_yawspeed);
-    Offboard::Result
-    set_acceleration_body_yawspeed_once(Offboard::AccelerationBodyYawspeed acceleration_ned_yawspeed);
+    Offboard::Result set_acceleration_body_yawspeed_once(
+        Offboard::AccelerationBodyYawspeed acceleration_ned_yawspeed);
     Offboard::Result set_velocity_body_once(Offboard::VelocityBodyYawspeed velocity_body_yawspeed);
     Offboard::Result set_velocity_body(Offboard::VelocityBodyYawspeed velocity_body_yawspeed);
     Offboard::Result set_attitude_once(Offboard::Attitude attitude);

--- a/src/plugins/telemetry/include/plugins/telemetry/telemetry.h
+++ b/src/plugins/telemetry/include/plugins/telemetry/telemetry.h
@@ -328,7 +328,7 @@ public:
     friend std::ostream& operator<<(std::ostream& str, Telemetry::RawGps const& raw_gps);
 
     /**
-     * @brief 
+     * @brief
      */
     struct GpsRtcmData {
         int32_t flags{0}; /**< @brief Fragment ID of RTCM data */
@@ -385,17 +385,19 @@ public:
      *
      * @return `true` if items are equal.
      */
-     friend bool operator==(const Telemetry::BatteryStatus& lhs, const Telemetry::BatteryStatus& rhs);
-
-     /**
-      * @brief Stream operator to print information about a `Telemetry::BatteryStatus`.
-      *
-      * @return A reference to the stream.
-      */
-     friend std::ostream& operator<<(std::ostream& str, Telemetry::BatteryStatus const& battery_status);
+    friend bool
+    operator==(const Telemetry::BatteryStatus& lhs, const Telemetry::BatteryStatus& rhs);
 
     /**
-     * @brief 
+     * @brief Stream operator to print information about a `Telemetry::BatteryStatus`.
+     *
+     * @return A reference to the stream.
+     */
+    friend std::ostream&
+    operator<<(std::ostream& str, Telemetry::BatteryStatus const& battery_status);
+
+    /**
+     * @brief
      */
     struct VehicleStatus {
         bool manual_control_signal_loss{false}; /**< @brief */
@@ -409,17 +411,19 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(const Telemetry::VehicleStatus& lhs, const Telemetry::VehicleStatus& rhs);
+    friend bool
+    operator==(const Telemetry::VehicleStatus& lhs, const Telemetry::VehicleStatus& rhs);
 
     /**
      * @brief Stream operator to print information about a `Telemetry::VehicleStatus`.
      *
      * @return A reference to the stream.
      */
-    friend std::ostream& operator<<(std::ostream& str, Telemetry::VehicleStatus const& vehicle_status);
+    friend std::ostream&
+    operator<<(std::ostream& str, Telemetry::VehicleStatus const& vehicle_status);
 
     /**
-     * @brief 
+     * @brief
      */
     struct ModeInfo {
         uint32_t base_mode{0}; /**< @brief */
@@ -569,7 +573,7 @@ public:
     operator<<(std::ostream& str, Telemetry::ActuatorOutputStatus const& actuator_output_status);
 
     /**
-     * @brief 
+     * @brief
      */
     struct ServoOutputRaw {
         uint64_t timestamp_us;
@@ -581,8 +585,8 @@ public:
      *
      * @return `true` if items are equal.
      */
-    friend bool operator==(
-        const Telemetry::ServoOutputRaw& lhs, const Telemetry::ServoOutputRaw& rhs);
+    friend bool
+    operator==(const Telemetry::ServoOutputRaw& lhs, const Telemetry::ServoOutputRaw& rhs);
 
     /**
      * @brief Covariance type.
@@ -665,13 +669,15 @@ public:
         /**
          * @brief Mavlink frame id
          */
-         enum class MavFrame {
+        enum class MavFrame {
             Undef = 0, /**< @brief Frame is undefined.. */
-            LocalNed = 1, /**< @brief Local coordinate frame, Z-down (x: North, y: East, z: Down). */
+            LocalNed =
+                1, /**< @brief Local coordinate frame, Z-down (x: North, y: East, z: Down). */
             BodyNed = 8, /**< @brief Setpoint in body NED frame. This makes sense if all position
                         control is externalized - e.g. useful to command 2 m/s^2 acceleration to the
                         right.. */
-            BodyFrd = 12, /**< @brief Body fixed frame of reference, Z-down (x: forward, y: right, z: down).. */
+            BodyFrd = 12, /**< @brief Body fixed frame of reference, Z-down (x: forward, y: right,
+                             z: down).. */
             VisionNed = 16, /**< @brief Odometry local coordinate frame of data given by a vision
                           estimation system, Z-down (x: north, y: east, z: down).. */
             EstimNed = 18, /**< @brief Odometry local coordinate frame of data given by an estimator
@@ -1269,7 +1275,7 @@ public:
     /**
      * @brief Subscribe to 'GPS 2 info' updates.
      */
-     void subscribe_gps_2_info(Gps2InfoCallback callback);
+    void subscribe_gps_2_info(Gps2InfoCallback callback);
 
     /**
      * @brief Poll for 'GpsInfo' (blocking).
@@ -1283,7 +1289,7 @@ public:
      *
      * @return One Gps2Info update.
      */
-     GpsInfo gps_2_info() const;
+    GpsInfo gps_2_info() const;
 
     /**
      * @brief Callback type for subscribe_raw_gps.
@@ -1305,7 +1311,7 @@ public:
     /**
      * @brief Subscribe to 'Raw GPS 2' updates.
      */
-     void subscribe_raw_gps_2(RawGps2Callback callback);
+    void subscribe_raw_gps_2(RawGps2Callback callback);
 
     /**
      * @brief Poll for 'RawGps' (blocking).
@@ -1319,12 +1325,12 @@ public:
      *
      * @return One RawGps2 update.
      */
-     RawGps raw_gps_2() const;
+    RawGps raw_gps_2() const;
 
     /**
-    * @brief Callback type for subscribe_gps_rtcm_data.
-    */
-        
+     * @brief Callback type for subscribe_gps_rtcm_data.
+     */
+
     using GpsRtcmDataCallback = std::function<void(GpsRtcmData)>;
 
     /**
@@ -1892,7 +1898,8 @@ public:
     /**
      * @brief Set rate to 'battery_status' updates.
      *
-     * This function is blocking. See 'set_rate_battery_status_async' for the non-blocking counterpart.
+     * This function is blocking. See 'set_rate_battery_status_async' for the non-blocking
+     * counterpart.
      *
      * @return Result of request.
      */

--- a/src/plugins/telemetry/include/plugins/telemetry/telemetry.h
+++ b/src/plugins/telemetry/include/plugins/telemetry/telemetry.h
@@ -328,7 +328,7 @@ public:
     friend std::ostream& operator<<(std::ostream& str, Telemetry::RawGps const& raw_gps);
 
     /**
-     * @brief
+     * @brief GPS RTCM data type.
      */
     struct GpsRtcmData {
         int32_t flags{0}; /**< @brief Fragment ID of RTCM data */
@@ -376,6 +376,9 @@ public:
      */
     friend std::ostream& operator<<(std::ostream& str, Telemetry::Battery const& battery);
 
+    /**
+     * @brief Battery status current type.
+     */
     struct BatteryStatus {
         float mah_consumed{float(NAN)}; /**< @brief current consumed in mAh */
     };
@@ -397,13 +400,14 @@ public:
     operator<<(std::ostream& str, Telemetry::BatteryStatus const& battery_status);
 
     /**
-     * @brief
+     * @brief Vehicle status type.
      */
     struct VehicleStatus {
-        bool manual_control_signal_loss{false}; /**< @brief */
-        bool data_link_loss{false}; /**< @brief */
-        bool rc_signal_loss{false}; /**< @brief */
-        uint32_t manual_contol_data_source{0}; /**< @brief */
+        bool manual_control_signal_loss{false}; /**< @brief True if manual control signal is loss */
+        bool data_link_loss{false}; /**< @brief True if the data link is loss */
+        bool rc_signal_loss{false}; /**< @brief True if RC signal is loss */
+        uint32_t manual_contol_data_source{
+            0}; /**< @brief Manual control source option, RC or MAVLink */
     };
 
     /**
@@ -423,11 +427,11 @@ public:
     operator<<(std::ostream& str, Telemetry::VehicleStatus const& vehicle_status);
 
     /**
-     * @brief
+     * @brief Mode info type.
      */
     struct ModeInfo {
-        uint32_t base_mode{0}; /**< @brief */
-        uint32_t custom_mode{0}; /**< @brief Custom mode (made up of main & sub mode). */
+        uint32_t base_mode{0}; /**< @brief Base mode flags */
+        uint32_t custom_mode{0}; /**< @brief Custom mode (made up of main & sub mode) */
     };
 
     /**
@@ -573,11 +577,11 @@ public:
     operator<<(std::ostream& str, Telemetry::ActuatorOutputStatus const& actuator_output_status);
 
     /**
-     * @brief
+     * @brief Servo output raw type.
      */
     struct ServoOutputRaw {
-        uint64_t timestamp_us;
-        uint16_t servo[16]; /**< @brief */
+        uint64_t timestamp_us; /**<@brief timestamp nanoseconds */
+        uint16_t servo[16]; /**< @brief servo array */
     };
 
     /**
@@ -986,8 +990,8 @@ public:
         AccelerationFrd acceleration_frd{}; /**< @brief Acceleration */
         AngularVelocityFrd angular_velocity_frd{}; /**< @brief Angular velocity */
         MagneticFieldFrd magnetic_field_frd{}; /**< @brief Magnetic field */
-        float abs_pressure{float(NAN)}; /**< @brief */
-        float pressure_alt{float(NAN)}; /**< @brief */
+        float abs_pressure{float(NAN)}; /**< @brief Absolute pressure */
+        float pressure_alt{float(NAN)}; /**< @brief Altitude pressure*/
         float temperature_degc{float(NAN)}; /**< @brief Temperature */
         uint64_t timestamp_us{}; /**< @brief Timestamp in microseconds */
     };

--- a/src/plugins/telemetry/include/plugins/telemetry/telemetry.h
+++ b/src/plugins/telemetry/include/plugins/telemetry/telemetry.h
@@ -1261,11 +1261,29 @@ public:
     void subscribe_gps_info(GpsInfoCallback callback);
 
     /**
+     * @brief Callback type for subscribe_gps_2_info.
+     */
+
+    using Gps2InfoCallback = std::function<void(GpsInfo)>;
+
+    /**
+     * @brief Subscribe to 'GPS 2 info' updates.
+     */
+     void subscribe_gps_2_info(GpsInfoCallback callback);
+
+    /**
      * @brief Poll for 'GpsInfo' (blocking).
      *
      * @return One GpsInfo update.
      */
     GpsInfo gps_info() const;
+
+    /**
+     * @brief Poll for 'Gps2Info' (blocking).
+     *
+     * @return One Gps2Info update.
+     */
+     GpsInfo gps_2_info() const;
 
     /**
      * @brief Callback type for subscribe_raw_gps.
@@ -1279,11 +1297,29 @@ public:
     void subscribe_raw_gps(RawGpsCallback callback);
 
     /**
+     * @brief Callback type for subscribe_raw_gps_2.
+     */
+
+    using RawGps2Callback = std::function<void(RawGps)>;
+
+    /**
+     * @brief Subscribe to 'Raw GPS 2' updates.
+     */
+     void subscribe_raw_gps_2(RawGpsCallback callback);
+
+    /**
      * @brief Poll for 'RawGps' (blocking).
      *
      * @return One RawGps update.
      */
     RawGps raw_gps() const;
+
+    /**
+     * @brief Poll for 'RawGps2' (blocking).
+     *
+     * @return One RawGps2 update.
+     */
+     RawGps raw_gps_2() const;
 
     /**
     * @brief Callback type for subscribe_gps_rtcm_data.

--- a/src/plugins/telemetry/include/plugins/telemetry/telemetry.h
+++ b/src/plugins/telemetry/include/plugins/telemetry/telemetry.h
@@ -1269,7 +1269,7 @@ public:
     /**
      * @brief Subscribe to 'GPS 2 info' updates.
      */
-     void subscribe_gps_2_info(GpsInfoCallback callback);
+     void subscribe_gps_2_info(Gps2InfoCallback callback);
 
     /**
      * @brief Poll for 'GpsInfo' (blocking).
@@ -1305,7 +1305,7 @@ public:
     /**
      * @brief Subscribe to 'Raw GPS 2' updates.
      */
-     void subscribe_raw_gps_2(RawGpsCallback callback);
+     void subscribe_raw_gps_2(RawGps2Callback callback);
 
     /**
      * @brief Poll for 'RawGps' (blocking).

--- a/src/plugins/telemetry/mocks/telemetry_mock.h
+++ b/src/plugins/telemetry/mocks/telemetry_mock.h
@@ -15,8 +15,12 @@ public:
     MOCK_CONST_METHOD1(subscribe_armed, void(Telemetry::ArmedCallback)){};
     MOCK_CONST_METHOD1(subscribe_gps_info, void(Telemetry::GpsInfoCallback)){};
     MOCK_CONST_METHOD1(subscribe_raw_gps, void(Telemetry::RawGpsCallback)){};
+    MOCK_CONST_METHOD1(subscribe_gps_rtcm_data, void(Telemetry::GpsRtcmDataCallback)){};
     MOCK_CONST_METHOD1(subscribe_battery, void(Telemetry::BatteryCallback)){};
+    MOCK_CONST_METHOD1(subscribe_battery_status, void(Telemetry::BatteryStatusCallback)){};
+    MOCK_CONST_METHOD1(subscribe_vehicle_status, void(Telemetry::VehicleStatusCallback)){};
     MOCK_CONST_METHOD1(subscribe_flight_mode, void(Telemetry::FlightModeCallback)){};
+    MOCK_CONST_METHOD1(subscribe_mode_info, void(Telemetry::ModeInfoCallback)){};
     MOCK_CONST_METHOD1(subscribe_landed_state, void(Telemetry::LandedStateCallback)){};
     MOCK_CONST_METHOD1(
         subscribe_attitude_quaternion, void(Telemetry::AttitudeQuaternionCallback)){};
@@ -33,6 +37,8 @@ public:
         subscribe_actuator_control_target, void(Telemetry::ActuatorControlTargetCallback)){};
     MOCK_CONST_METHOD1(
         subscribe_actuator_output_status, void(Telemetry::ActuatorOutputStatusCallback)){};
+    MOCK_CONST_METHOD1(
+        subscribe_servo_output_raw, void(Telemetry::ServoOutputRawCallback callback)){};
     MOCK_CONST_METHOD1(subscribe_odometry, void(Telemetry::OdometryCallback)){};
     MOCK_CONST_METHOD1(subscribe_distance_sensor, void(Telemetry::DistanceSensorCallback)){};
     MOCK_CONST_METHOD1(subscribe_scaled_pressure, void(Telemetry::ScaledPressureCallback)){};
@@ -56,6 +62,7 @@ public:
     MOCK_METHOD1(set_rate_gps_info, Telemetry::Result(double)){};
     MOCK_METHOD1(set_rate_raw_gps, Telemetry::Result(double)){};
     MOCK_METHOD1(set_rate_battery, Telemetry::Result(double)){};
+    MOCK_METHOD1(set_rate_battery_status, Telemetry::Result(double)){};
     MOCK_METHOD1(set_rate_rc_status, Telemetry::Result(double)){};
     MOCK_METHOD1(set_rate_actuator_control_target, Telemetry::Result(double)){};
     MOCK_METHOD1(set_rate_actuator_output_status, Telemetry::Result(double)){};

--- a/src/plugins/telemetry/telemetry.cpp
+++ b/src/plugins/telemetry/telemetry.cpp
@@ -169,9 +169,19 @@ void Telemetry::subscribe_gps_info(GpsInfoCallback callback)
     _impl->subscribe_gps_info(callback);
 }
 
+void Telemetry::subscribe_gps_2_info(Gps2InfoCallback callback)
+{
+    _impl->subscribe_gps_2_info(callback);
+}
+
 Telemetry::GpsInfo Telemetry::gps_info() const
 {
     return _impl->gps_info();
+}
+
+Telemetry::GpsInfo Telemetry::gps_2_info() const
+{
+    return _impl->gps_2_info();
 }
 
 void Telemetry::subscribe_raw_gps(RawGpsCallback callback)
@@ -179,9 +189,19 @@ void Telemetry::subscribe_raw_gps(RawGpsCallback callback)
     _impl->subscribe_raw_gps(callback);
 }
 
+void Telemetry::subscribe_raw_gps_2(RawGps2Callback callback)
+{
+    _impl->subscribe_raw_gps_2(callback);
+}
+
 Telemetry::RawGps Telemetry::raw_gps() const
 {
     return _impl->raw_gps();
+}
+
+Telemetry::RawGps Telemetry::raw_gps_2() const
+{
+    return _impl->raw_gps_2();
 }
 
 void Telemetry::subscribe_gps_rtcm_data(GpsRtcmDataCallback callback)

--- a/src/plugins/telemetry/telemetry.cpp
+++ b/src/plugins/telemetry/telemetry.cpp
@@ -834,9 +834,7 @@ std::ostream& operator<<(std::ostream& str, Telemetry::GpsRtcmData const& gps_rt
     str << "    flags: " << gps_rtcm_data.flags << '\n';
     str << "    len: " << gps_rtcm_data.len << '\n';
     str << "    data: [";
-    for (auto it = gps_rtcm_data.data.begin();
-        it != gps_rtcm_data.data.end();
-        ++it) {
+    for (auto it = gps_rtcm_data.data.begin(); it != gps_rtcm_data.data.end(); ++it) {
         str << *it;
         str << (it + 1 != gps_rtcm_data.data.end() ? ", " : "]\n");
     }
@@ -886,11 +884,10 @@ std::ostream& operator<<(std::ostream& str, Telemetry::BatteryStatus const& batt
 
 bool operator==(const Telemetry::VehicleStatus& lhs, const Telemetry::VehicleStatus& rhs)
 {
-    return
-        (rhs.manual_control_signal_loss == lhs.manual_control_signal_loss) &&
-        (rhs.data_link_loss == lhs.data_link_loss) &&
-        (rhs.rc_signal_loss == lhs.rc_signal_loss) &&
-        (rhs.manual_contol_data_source == lhs.manual_contol_data_source);
+    return (rhs.manual_control_signal_loss == lhs.manual_control_signal_loss) &&
+           (rhs.data_link_loss == lhs.data_link_loss) &&
+           (rhs.rc_signal_loss == lhs.rc_signal_loss) &&
+           (rhs.manual_contol_data_source == lhs.manual_contol_data_source);
 }
 
 std::ostream& operator<<(std::ostream& str, Telemetry::VehicleStatus const& vehicle_status)
@@ -907,9 +904,7 @@ std::ostream& operator<<(std::ostream& str, Telemetry::VehicleStatus const& vehi
 
 bool operator==(const Telemetry::ModeInfo& lhs, const Telemetry::ModeInfo& rhs)
 {
-    return
-        (rhs.base_mode == lhs.base_mode) &&
-        (rhs.custom_mode == lhs.custom_mode);
+    return (rhs.base_mode == lhs.base_mode) && (rhs.custom_mode == lhs.custom_mode);
 }
 
 std::ostream& operator<<(std::ostream& str, Telemetry::ModeInfo const& mode_info)

--- a/src/plugins/telemetry/telemetry_impl.cpp
+++ b/src/plugins/telemetry/telemetry_impl.cpp
@@ -69,7 +69,9 @@ void TelemetryImpl::init()
         MAVLINK_MSG_ID_GPS2_RAW, std::bind(&TelemetryImpl::process_gps_2_raw, this, _1), this);
 
     _parent->register_mavlink_message_handler(
-        MAVLINK_MSG_ID_GPS_RTCM_DATA, std::bind(&TelemetryImpl::process_gps_rtcm_data, this, _1), this);
+        MAVLINK_MSG_ID_GPS_RTCM_DATA,
+        std::bind(&TelemetryImpl::process_gps_rtcm_data, this, _1),
+        this);
 
     _parent->register_mavlink_message_handler(
         MAVLINK_MSG_ID_EXTENDED_SYS_STATE,
@@ -323,7 +325,7 @@ Telemetry::Result TelemetryImpl::set_rate_battery(double rate_hz)
 Telemetry::Result TelemetryImpl::set_rate_battery_status(double rate_hz)
 {
     return telemetry_result_from_command_result(
-            _parent->set_msg_rate(MAVLINK_MSG_ID_BATTERY_STATUS, rate_hz));
+        _parent->set_msg_rate(MAVLINK_MSG_ID_BATTERY_STATUS, rate_hz));
 }
 
 Telemetry::Result TelemetryImpl::set_rate_rc_status(double rate_hz)
@@ -495,7 +497,8 @@ void TelemetryImpl::set_rate_battery_async(double rate_hz, Telemetry::ResultCall
         std::bind(&TelemetryImpl::command_result_callback, std::placeholders::_1, callback));
 }
 
-void TelemetryImpl::set_rate_battery_status_async(double rate_hz, Telemetry::ResultCallback callback)
+void TelemetryImpl::set_rate_battery_status_async(
+    double rate_hz, Telemetry::ResultCallback callback)
 {
     _parent->set_msg_rate_async(
         MAVLINK_MSG_ID_BATTERY_STATUS,
@@ -1199,10 +1202,14 @@ void TelemetryImpl::process_sys_status(const mavlink_message_t& message)
     }
 
     Telemetry::VehicleStatus new_vehicle_status;
-    new_vehicle_status.manual_control_signal_loss = sys_status.errors_count1;  // No manual_control setpoint messages arriving (can come from RC or MAV)
-    new_vehicle_status.data_link_loss = sys_status.errors_count2;  // No messages from GCS received
+    new_vehicle_status.manual_control_signal_loss =
+        sys_status.errors_count1; // No manual_control setpoint messages arriving (can come from RC
+                                  // or MAV)
+    new_vehicle_status.data_link_loss = sys_status.errors_count2; // No messages from GCS received
     new_vehicle_status.rc_signal_loss = sys_status.errors_count3; // No messages from RC TX received
-    new_vehicle_status.manual_contol_data_source = sys_status.errors_count4; // Indicates whether the drone is controlled by RC (1) or MAVLink (2-5)
+    new_vehicle_status.manual_contol_data_source =
+        sys_status
+            .errors_count4; // Indicates whether the drone is controlled by RC (1) or MAVLink (2-5)
 
     set_vehicle_status(new_vehicle_status);
 
@@ -1222,7 +1229,6 @@ void TelemetryImpl::process_battery_status(const mavlink_message_t& message)
     mavlink_msg_battery_status_decode(&message, &bat_status);
 
     if (!_has_bat_status) {
-
         _has_bat_status = false;
 
         Telemetry::BatteryStatus new_battery_status;
@@ -1237,7 +1243,6 @@ void TelemetryImpl::process_battery_status(const mavlink_message_t& message)
         }
 
     } else {
-
         _has_bat_status = true;
 
         Telemetry::Battery new_battery;
@@ -2406,8 +2411,7 @@ void TelemetryImpl::subscribe_actuator_output_status(
     _actuator_output_status_subscription = callback;
 }
 
-void TelemetryImpl::subscribe_servo_output_raw(
-    Telemetry::ServoOutputRawCallback& callback)
+void TelemetryImpl::subscribe_servo_output_raw(Telemetry::ServoOutputRawCallback& callback)
 {
     std::lock_guard<std::mutex> lock(_subscription_mutex);
     _servo_output_raw_subscription = callback;

--- a/src/plugins/telemetry/telemetry_impl.cpp
+++ b/src/plugins/telemetry/telemetry_impl.cpp
@@ -982,7 +982,7 @@ void TelemetryImpl::process_gps_raw_int(const mavlink_message_t& message)
     _parent->refresh_timeout_handler(_gps_raw_timeout_cookie);
 }
 
-void TelemetryImpl::process_gps_2_raw(const int& message)
+void TelemetryImpl::process_gps_2_raw(const mavlink_message_t& message)
 {
     mavlink_gps2_raw_t gps_2_raw;
     mavlink_msg_gps2_raw_decode(&message, &gps_2_raw);

--- a/src/plugins/telemetry/telemetry_impl.h
+++ b/src/plugins/telemetry/telemetry_impl.h
@@ -39,6 +39,7 @@ public:
     Telemetry::Result set_rate_fixedwing_metrics(double rate_hz);
     Telemetry::Result set_rate_ground_truth(double rate_hz);
     Telemetry::Result set_rate_gps_info(double rate_hz);
+    Telemetry::Result set_rate_gps_2_info(double rate_hz);
     Telemetry::Result set_rate_battery(double rate_hz);
     Telemetry::Result set_rate_battery_status(double rate_hz);
     Telemetry::Result set_rate_rc_status(double rate_hz);
@@ -63,6 +64,7 @@ public:
     void set_rate_fixedwing_metrics_async(double rate_hz, Telemetry::ResultCallback callback);
     void set_rate_ground_truth_async(double rate_hz, Telemetry::ResultCallback callback);
     void set_rate_gps_info_async(double rate_hz, Telemetry::ResultCallback callback);
+    void set_rate_gps_2_info_async(double rate_hz, Telemetry::ResultCallback callback);
     void set_rate_battery_async(double rate_hz, Telemetry::ResultCallback callback);
     void set_rate_battery_status_async(double rate_hz, Telemetry::ResultCallback callback);
     void set_rate_rc_status_async(double rate_hz, Telemetry::ResultCallback callback);
@@ -95,7 +97,9 @@ public:
     Telemetry::Imu scaled_imu() const;
     Telemetry::Imu raw_imu() const;
     Telemetry::GpsInfo gps_info() const;
+    Telemetry::GpsInfo gps_2_info() const;
     Telemetry::RawGps raw_gps() const;
+    Telemetry::RawGps raw_gps_2() const;
     Telemetry::GpsRtcmData gps_rtcm_data() const;
     Telemetry::Battery battery() const;
     Telemetry::BatteryStatus battery_status() const;
@@ -132,7 +136,9 @@ public:
     void subscribe_scaled_imu(Telemetry::ScaledImuCallback& callback);
     void subscribe_raw_imu(Telemetry::RawImuCallback& callback);
     void subscribe_gps_info(Telemetry::GpsInfoCallback& callback);
+    void subscribe_gps_2_info(Telemetry::Gps2InfoCallback& callback);
     void subscribe_raw_gps(Telemetry::RawGpsCallback& callback);
+    void subscribe_raw_gps_2(Telemetry::RawGps2Callback& callback);
     void subscribe_gps_rtcm_data(Telemetry::GpsRtcmDataCallback& callback);
     void subscribe_battery(Telemetry::BatteryCallback& callback);
     void subscribe_battery_status(Telemetry::BatteryStatusCallback& callback);
@@ -172,7 +178,9 @@ private:
     void set_scaled_imu(Telemetry::Imu imu);
     void set_raw_imu(Telemetry::Imu imu);
     void set_gps_info(Telemetry::GpsInfo gps_info);
+    void set_gps_2_info(Telemetry::GpsInfo gps_2_info);
     void set_raw_gps(Telemetry::RawGps raw_gps);
+    void set_raw_gps_2(Telemetry::RawGps raw_gps_2);
     void set_gps_rtcm_data(Telemetry::GpsRtcmData gps_rtcm_data);
     void set_battery(Telemetry::Battery battery);
     void set_battery_status(Telemetry::BatteryStatus battery_status);
@@ -204,6 +212,7 @@ private:
     void process_scaled_imu(const mavlink_message_t& message);
     void process_raw_imu(const mavlink_message_t& message);
     void process_gps_raw_int(const mavlink_message_t& message);
+    void process_gps_2_raw(const mavlink_message_t& message);
     void process_gps_rtcm_data(const mavlink_message_t& message);
     void process_ground_truth(const mavlink_message_t& message);
     void process_extended_sys_state(const mavlink_message_t& message);
@@ -292,8 +301,14 @@ private:
     mutable std::mutex _gps_info_mutex{};
     Telemetry::GpsInfo _gps_info{};
 
+    mutable std::mutex _gps_2_info_mutex{};
+    Telemetry::GpsInfo _gps_2_info{};
+
     mutable std::mutex _raw_gps_mutex{};
     Telemetry::RawGps _raw_gps{};
+
+    mutable std::mutex _raw_gps_2_mutex{};
+    Telemetry::RawGps _raw_gps_2{};
 
     mutable std::mutex _gps_rtcm_data_mutex{};
     Telemetry::GpsRtcmData _gps_rtcm_data{};
@@ -359,7 +374,9 @@ private:
     Telemetry::ScaledImuCallback _scaled_imu_subscription{nullptr};
     Telemetry::RawImuCallback _raw_imu_subscription{nullptr};
     Telemetry::GpsInfoCallback _gps_info_subscription{nullptr};
+    Telemetry::Gps2InfoCallback _gps_2_info_subscription{nullptr};
     Telemetry::RawGpsCallback _raw_gps_subscription{nullptr};
+    Telemetry::RawGps2Callback _raw_gps_2_subscription{nullptr};
     Telemetry::GpsRtcmDataCallback _gps_rtcm_data_subscription{nullptr};
     Telemetry::BatteryCallback _battery_subscription{nullptr};
     Telemetry::BatteryStatusCallback _battery_status_subscription{nullptr};


### PR DESCRIPTION
This pull request adds MAVLink information of secondary GPS data which can be used for SI2 (Refer to: https://github.com/SEESAI/SeesInterface2/pull/323). 