### PR TITLE
PX4 Component ID Parameter Update

### DIFF
--- a/src/mavsdk/core/mavlink_parameters.cpp
+++ b/src/mavsdk/core/mavlink_parameters.cpp
@@ -681,7 +681,15 @@ void MAVLinkParameters::do_work()
     char param_id[PARAM_ID_LEN + 1] = {};
     strncpy(param_id, work->param_name.c_str(), sizeof(param_id) - 1);
 
-    uint8_t component_id = [&]() {
+    uint8_t current_component_id = [&]() {
+        if (work->maybe_component_id) {
+            return work->maybe_component_id.value();
+        } else {
+            return _parent.get_own_component_id();
+        }
+    }();
+
+    uint8_t target_component_id = [&]() {
         if (work->maybe_component_id) {
             return work->maybe_component_id.value();
         } else {
@@ -719,10 +727,10 @@ void MAVLinkParameters::do_work()
                 // FIXME: extended currently always go to the camera component
                 mavlink_msg_param_ext_set_pack(
                     _parent.get_own_system_id(),
-                    _parent.get_own_component_id(),
+                    current_component_id,
                     &work->mavlink_message,
                     _parent.get_system_id(),
-                    component_id,
+                    target_component_id,
                     param_id,
                     param_value_buf.data(),
                     work->param_value.get_mav_param_ext_type());
@@ -733,10 +741,10 @@ void MAVLinkParameters::do_work()
 
                 mavlink_msg_param_set_pack(
                     _parent.get_own_system_id(),
-                    _parent.get_own_component_id(),
+                    current_component_id,
                     &work->mavlink_message,
                     _parent.get_system_id(),
-                    component_id,
+                    target_component_id,
                     param_id,
                     value_set,
                     work->param_value.get_mav_param_type());
@@ -768,10 +776,10 @@ void MAVLinkParameters::do_work()
             if (work->extended) {
                 mavlink_msg_param_ext_request_read_pack(
                     _parent.get_own_system_id(),
-                    _parent.get_own_component_id(),
+                    current_component_id,
                     &work->mavlink_message,
                     _parent.get_system_id(),
-                    component_id,
+                    target_component_id,
                     param_id,
                     -1);
 
@@ -785,10 +793,10 @@ void MAVLinkParameters::do_work()
 
                 mavlink_msg_param_request_read_pack(
                     _parent.get_own_system_id(),
-                    _parent.get_own_component_id(),
+                    current_component_id,
                     &work->mavlink_message,
                     _parent.get_system_id(),
-                    component_id,
+                    target_component_id,
                     param_id,
                     -1);
             }
@@ -828,7 +836,7 @@ void MAVLinkParameters::do_work()
                 auto buf = work->param_value.get_128_bytes();
                 mavlink_msg_param_ext_value_pack(
                     _parent.get_own_system_id(),
-                    _parent.get_own_component_id(),
+                    current_component_id,
                     &work->mavlink_message,
                     param_id,
                     buf.data(),
@@ -844,7 +852,7 @@ void MAVLinkParameters::do_work()
                 }
                 mavlink_msg_param_value_pack(
                     _parent.get_own_system_id(),
-                    _parent.get_own_component_id(),
+                    current_component_id,
                     &work->mavlink_message,
                     param_id,
                     param_value,
@@ -868,7 +876,7 @@ void MAVLinkParameters::do_work()
                 auto buf = work->param_value.get_128_bytes();
                 mavlink_msg_param_ext_ack_pack(
                     _parent.get_own_system_id(),
-                    _parent.get_own_component_id(),
+                    current_component_id,
                     &work->mavlink_message,
                     param_id,
                     buf.data(),

--- a/src/mavsdk/core/mavlink_parameters.cpp
+++ b/src/mavsdk/core/mavlink_parameters.cpp
@@ -681,15 +681,7 @@ void MAVLinkParameters::do_work()
     char param_id[PARAM_ID_LEN + 1] = {};
     strncpy(param_id, work->param_name.c_str(), sizeof(param_id) - 1);
 
-    uint8_t current_component_id = [&]() {
-        if (work->maybe_component_id) {
-            return work->maybe_component_id.value();
-        } else {
-            return _parent.get_own_component_id();
-        }
-    }();
-
-    uint8_t target_component_id = [&]() {
+    uint8_t component_id = [&]() {
         if (work->maybe_component_id) {
             return work->maybe_component_id.value();
         } else {
@@ -727,10 +719,10 @@ void MAVLinkParameters::do_work()
                 // FIXME: extended currently always go to the camera component
                 mavlink_msg_param_ext_set_pack(
                     _parent.get_own_system_id(),
-                    current_component_id,
+                    _parent.get_own_component_id(),
                     &work->mavlink_message,
                     _parent.get_system_id(),
-                    target_component_id,
+                    component_id,
                     param_id,
                     param_value_buf.data(),
                     work->param_value.get_mav_param_ext_type());
@@ -741,10 +733,10 @@ void MAVLinkParameters::do_work()
 
                 mavlink_msg_param_set_pack(
                     _parent.get_own_system_id(),
-                    current_component_id,
+                    _parent.get_own_component_id(),
                     &work->mavlink_message,
                     _parent.get_system_id(),
-                    target_component_id,
+                    component_id,
                     param_id,
                     value_set,
                     work->param_value.get_mav_param_type());
@@ -776,10 +768,10 @@ void MAVLinkParameters::do_work()
             if (work->extended) {
                 mavlink_msg_param_ext_request_read_pack(
                     _parent.get_own_system_id(),
-                    current_component_id,
+                    _parent.get_own_component_id(),
                     &work->mavlink_message,
                     _parent.get_system_id(),
-                    target_component_id,
+                    component_id,
                     param_id,
                     -1);
 
@@ -793,10 +785,10 @@ void MAVLinkParameters::do_work()
 
                 mavlink_msg_param_request_read_pack(
                     _parent.get_own_system_id(),
-                    current_component_id,
+                    _parent.get_own_component_id(),
                     &work->mavlink_message,
                     _parent.get_system_id(),
-                    target_component_id,
+                    component_id,
                     param_id,
                     -1);
             }
@@ -836,7 +828,7 @@ void MAVLinkParameters::do_work()
                 auto buf = work->param_value.get_128_bytes();
                 mavlink_msg_param_ext_value_pack(
                     _parent.get_own_system_id(),
-                    current_component_id,
+                    _parent.get_own_component_id(),
                     &work->mavlink_message,
                     param_id,
                     buf.data(),
@@ -852,7 +844,7 @@ void MAVLinkParameters::do_work()
                 }
                 mavlink_msg_param_value_pack(
                     _parent.get_own_system_id(),
-                    current_component_id,
+                    _parent.get_own_component_id(),
                     &work->mavlink_message,
                     param_id,
                     param_value,
@@ -876,7 +868,7 @@ void MAVLinkParameters::do_work()
                 auto buf = work->param_value.get_128_bytes();
                 mavlink_msg_param_ext_ack_pack(
                     _parent.get_own_system_id(),
-                    current_component_id,
+                    _parent.get_own_component_id(),
                     &work->mavlink_message,
                     param_id,
                     buf.data(),

--- a/src/mavsdk/core/system_impl.cpp
+++ b/src/mavsdk/core/system_impl.cpp
@@ -795,14 +795,14 @@ std::map<std::string, MAVLinkParameters::ParamValue> SystemImpl::retrieve_all_se
     return _params.retrieve_all_server_params();
 }
 
-std::pair<MAVLinkParameters::Result, float> SystemImpl::get_param_float(const std::string& name)
+std::pair<MAVLinkParameters::Result, float> SystemImpl::get_param_float(const std::string& name, std::optional<uint8_t> maybe_component_id)
 {
-    return _params.get_param_float(name, {}, false);
+    return _params.get_param_float(name, maybe_component_id, false);
 }
 
-std::pair<MAVLinkParameters::Result, int> SystemImpl::get_param_int(const std::string& name)
+std::pair<MAVLinkParameters::Result, int> SystemImpl::get_param_int(const std::string& name, std::optional<uint8_t> maybe_component_id)
 {
-    return _params.get_param_int(name, {}, false);
+    return _params.get_param_int(name, maybe_component_id, false);
 }
 
 std::pair<MAVLinkParameters::Result, std::string>

--- a/src/mavsdk/core/system_impl.h
+++ b/src/mavsdk/core/system_impl.h
@@ -268,8 +268,8 @@ public:
     std::pair<MAVLinkParameters::Result, std::string>
     retrieve_server_param_custom(const std::string& name);
 
-    std::pair<MAVLinkParameters::Result, float> get_param_float(const std::string& name);
-    std::pair<MAVLinkParameters::Result, int> get_param_int(const std::string& name);
+    std::pair<MAVLinkParameters::Result, float> get_param_float(const std::string& name, std::optional<uint8_t> maybe_component_id = {});
+    std::pair<MAVLinkParameters::Result, int> get_param_int(const std::string& name, std::optional<uint8_t> maybe_component_id = {});
     std::pair<MAVLinkParameters::Result, float> get_param_ext_float(const std::string& name);
     std::pair<MAVLinkParameters::Result, int> get_param_ext_int(const std::string& name);
     std::pair<MAVLinkParameters::Result, std::string> get_param_custom(const std::string& name);

--- a/src/mavsdk/plugins/param/include/plugins/param/param.h
+++ b/src/mavsdk/plugins/param/include/plugins/param/param.h
@@ -9,6 +9,7 @@
 #include <functional>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>

--- a/src/mavsdk/plugins/param/include/plugins/param/param.h
+++ b/src/mavsdk/plugins/param/include/plugins/param/param.h
@@ -183,7 +183,7 @@ public:
      *
      * @return Result of request.
      */
-    std::pair<Result, int32_t> get_param_int(std::string name) const;
+    std::pair<Result, int32_t> get_param_int(std::string name, std::optional<uint8_t> maybe_component_id = {}) const;
 
     /**
      * @brief Set an int parameter.
@@ -205,7 +205,7 @@ public:
      *
      * @return Result of request.
      */
-    std::pair<Result, float> get_param_float(std::string name) const;
+    std::pair<Result, float> get_param_float(std::string name, std::optional<uint8_t> maybe_component_id = {}) const;
 
     /**
      * @brief Set a float parameter.

--- a/src/mavsdk/plugins/param/param.cpp
+++ b/src/mavsdk/plugins/param/param.cpp
@@ -23,9 +23,9 @@ Param::Param(std::shared_ptr<System> system) :
 
 Param::~Param() {}
 
-std::pair<Param::Result, int32_t> Param::get_param_int(std::string name) const
+std::pair<Param::Result, int32_t> Param::get_param_int(std::string name, std::optional<uint8_t> maybe_component_id) const
 {
-    return _impl->get_param_int(name);
+    return _impl->get_param_int(name, maybe_component_id);
 }
 
 Param::Result Param::set_param_int(std::string name, int32_t value) const
@@ -33,9 +33,9 @@ Param::Result Param::set_param_int(std::string name, int32_t value) const
     return _impl->set_param_int(name, value);
 }
 
-std::pair<Param::Result, float> Param::get_param_float(std::string name) const
+std::pair<Param::Result, float> Param::get_param_float(std::string name, std::optional<uint8_t> maybe_component_id) const
 {
-    return _impl->get_param_float(name);
+    return _impl->get_param_float(name, maybe_component_id);
 }
 
 Param::Result Param::set_param_float(std::string name, float value) const

--- a/src/mavsdk/plugins/param/param_impl.cpp
+++ b/src/mavsdk/plugins/param/param_impl.cpp
@@ -27,9 +27,9 @@ void ParamImpl::enable() {}
 
 void ParamImpl::disable() {}
 
-std::pair<Param::Result, int32_t> ParamImpl::get_param_int(const std::string& name)
+std::pair<Param::Result, int32_t> ParamImpl::get_param_int(const std::string& name, std::optional<uint8_t> maybe_component_id)
 {
-    std::pair<MAVLinkParameters::Result, int32_t> result = _parent->get_param_int(name);
+    std::pair<MAVLinkParameters::Result, int32_t> result = _parent->get_param_int(name, maybe_component_id);
     return std::make_pair<>(result_from_mavlink_parameters_result(result.first), result.second);
 }
 
@@ -39,9 +39,9 @@ Param::Result ParamImpl::set_param_int(const std::string& name, int32_t value)
     return result_from_mavlink_parameters_result(result);
 }
 
-std::pair<Param::Result, float> ParamImpl::get_param_float(const std::string& name)
+std::pair<Param::Result, float> ParamImpl::get_param_float(const std::string& name, std::optional<uint8_t> maybe_component_id)
 {
-    std::pair<MAVLinkParameters::Result, float> result = _parent->get_param_float(name);
+    std::pair<MAVLinkParameters::Result, float> result = _parent->get_param_float(name, maybe_component_id);
     return std::make_pair<>(result_from_mavlink_parameters_result(result.first), result.second);
 }
 

--- a/src/mavsdk/plugins/param/param_impl.h
+++ b/src/mavsdk/plugins/param/param_impl.h
@@ -20,11 +20,11 @@ public:
     void enable() override;
     void disable() override;
 
-    std::pair<Param::Result, int32_t> get_param_int(const std::string& name);
+    std::pair<Param::Result, int32_t> get_param_int(const std::string& name, std::optional<uint8_t> maybe_component_id = {});
 
     Param::Result set_param_int(const std::string& name, int32_t value);
 
-    std::pair<Param::Result, float> get_param_float(const std::string& name);
+    std::pair<Param::Result, float> get_param_float(const std::string& name, std::optional<uint8_t> maybe_component_id = {});
 
     Param::Result set_param_float(const std::string& name, float value);
 


### PR DESCRIPTION
This PR adds feature to handle remote component update, i.e. with CAN component. The full details are specified in the following PR: https://github.com/SEESAI/SeesInterface2/pull/457.