### PR TITLE
Backuplink Telemetry Update

### DIFF
--- a/src/mavsdk/plugins/telemetry/include/plugins/telemetry/telemetry.h
+++ b/src/mavsdk/plugins/telemetry/include/plugins/telemetry/telemetry.h
@@ -458,7 +458,7 @@ public:
      */
     struct VehicleStatus {
         bool manual_control_signal_loss{false}; /**< @brief True if manual control signal is loss */
-        uint32_t mavlink_count{false}; /**< @brief Number of Mavlink connections providing setpoints (implying joystick connected). Should be < 2.*/
+        uint32_t mavlink_count{0}; /**< @brief Number of Mavlink connections providing setpoints (implying joystick connected). Should be < 2.*/
         bool rc_signal_loss{false}; /**< @brief True if RC signal is loss */
         uint32_t sees_desired_control_source{0}; /**< @brief Desired type of manual control source, RC (1) or Mav (2)  */
     };

--- a/src/mavsdk/plugins/telemetry/include/plugins/telemetry/telemetry.h
+++ b/src/mavsdk/plugins/telemetry/include/plugins/telemetry/telemetry.h
@@ -458,9 +458,9 @@ public:
      */
     struct VehicleStatus {
         bool manual_control_signal_loss{false}; /**< @brief True if manual control signal is loss */
-        bool data_link_loss{false}; /**< @brief True if the data link is loss */
+        uint32_t mavlink_count{false}; /**< @brief Number of Mavlink connections providing setpoints (implying joystick connected). Should be < 2.*/
         bool rc_signal_loss{false}; /**< @brief True if RC signal is loss */
-        uint32_t manual_control_data_source{0}; /**< @brief Manual control source option, RC or MAVLink */
+        uint32_t sees_desired_control_source{0}; /**< @brief Desired type of manual control source, RC (1) or Mav (2)  */
     };
     
     /**

--- a/src/mavsdk/plugins/telemetry/telemetry.cpp
+++ b/src/mavsdk/plugins/telemetry/telemetry.cpp
@@ -980,9 +980,9 @@ std::ostream& operator<<(std::ostream& str, Telemetry::Battery const& battery)
 bool operator==(const Telemetry::VehicleStatus& lhs, const Telemetry::VehicleStatus& rhs)
 {
     return (rhs.manual_control_signal_loss == lhs.manual_control_signal_loss) &&
-           (rhs.data_link_loss == lhs.data_link_loss) &&
+           (rhs.mavlink_count == lhs.mavlink_count) &&
            (rhs.rc_signal_loss == lhs.rc_signal_loss) && 
-           (rhs.manual_control_data_source == lhs.manual_control_data_source);
+           (rhs.sees_desired_control_source == lhs.sees_desired_control_source);
 }
 
 std::ostream& operator<<(std::ostream& str, Telemetry::VehicleStatus const& vehicle_status)
@@ -990,9 +990,9 @@ std::ostream& operator<<(std::ostream& str, Telemetry::VehicleStatus const& vehi
     str << std::setprecision(15);
     str << "vehicle_status:" << '\n' << "{\n";
     str << "    manual_control_signal_loss: " << vehicle_status.manual_control_signal_loss << '\n';
-    str << "    data_link_loss: " << vehicle_status.data_link_loss << '\n';
+    str << "    mavlink_count: " << vehicle_status.mavlink_count << '\n';
     str << "    rc_signal_loss: " << vehicle_status.rc_signal_loss << '\n';
-    str << "    manual_control_data_source: " << vehicle_status.manual_control_data_source << '\n';
+    str << "    sees_desired_control_source: " << vehicle_status.sees_desired_control_source << '\n';
     str << '}';
     return str;
 }

--- a/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
+++ b/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
@@ -1296,10 +1296,10 @@ void TelemetryImpl::process_sys_status(const mavlink_message_t& message)
     }
     
         Telemetry::VehicleStatus new_vehicle_status;
-    new_vehicle_status.manual_control_signal_loss = sys_status.errors_count1; // No manual control setpoint messages arriving (can come from RC or MAV)
-    new_vehicle_status.data_link_loss = sys_status.errors_count2; // No messages from GCS received
+    new_vehicle_status.manual_control_signal_loss = sys_status.errors_count1; // No manual control setpoint messages arriving from the desired source
+    new_vehicle_status.mavlink_count = sys_status.errors_count2; // Number of (live) Mavlink Joysticks connected
     new_vehicle_status.rc_signal_loss = sys_status.errors_count3; // No messages from RC TX received
-    new_vehicle_status.manual_control_data_source = sys_status.errors_count4; // Indicates whether the drone is controlled by RC (1) or MAVLink (2-5)
+    new_vehicle_status.sees_desired_control_source = sys_status.errors_count4; // Indicates desired manual control source, RC (1) or MAVLink (2)
     
     set_vehicle_status(new_vehicle_status);
     


### PR DESCRIPTION
This PR is interlinked with these:
- [PX4 PR](https://github.com/SEESAI/Firmware/pull/62)
- [SI2 PR](https://github.com/SEESAI/SeesInterface2/pull/556)

For more detail, refer to those.

In short, we are now looking at the number of Mavlink connections providing setpoints (joystick connected) to determine if Backup GCS is connected.
We are also now monitoring the _desired_ source as this is more informative with the way we toggle between source types.