### PR TITLE
RC Connected Status Indicator Fix

### DIFF
--- a/src/mavsdk/plugins/telemetry/include/plugins/telemetry/telemetry.h
+++ b/src/mavsdk/plugins/telemetry/include/plugins/telemetry/telemetry.h
@@ -459,7 +459,7 @@ public:
     struct VehicleStatus {
         bool manual_control_signal_loss{false}; /**< @brief True if manual control signal is loss */
         uint32_t mavlink_count{0}; /**< @brief Number of Mavlink connections providing setpoints (implying joystick connected). Should be < 2.*/
-        bool rc_signal_loss{false}; /**< @brief True if RC signal is loss */
+        uint32_t valid_rc_setpoint_count{false}; /**< @brief True if RC signal is loss */
         uint32_t sees_desired_control_source{0}; /**< @brief Desired type of manual control source, RC (1) or Mav (2)  */
     };
     

--- a/src/mavsdk/plugins/telemetry/include/plugins/telemetry/telemetry.h
+++ b/src/mavsdk/plugins/telemetry/include/plugins/telemetry/telemetry.h
@@ -459,7 +459,7 @@ public:
     struct VehicleStatus {
         bool manual_control_signal_loss{false}; /**< @brief True if manual control signal is loss */
         uint32_t mavlink_count{0}; /**< @brief Number of Mavlink connections providing setpoints (implying joystick connected). Should be < 2.*/
-        uint32_t valid_rc_setpoint_count{false}; /**< @brief True if RC signal is loss */
+        uint32_t rc_count{0}; /**< @brief Number of RC connections providing setpoints (implying joystick connected). Should be < 2.*/
         uint32_t sees_desired_control_source{0}; /**< @brief Desired type of manual control source, RC (1) or Mav (2)  */
     };
     

--- a/src/mavsdk/plugins/telemetry/telemetry.cpp
+++ b/src/mavsdk/plugins/telemetry/telemetry.cpp
@@ -981,7 +981,7 @@ bool operator==(const Telemetry::VehicleStatus& lhs, const Telemetry::VehicleSta
 {
     return (rhs.manual_control_signal_loss == lhs.manual_control_signal_loss) &&
            (rhs.mavlink_count == lhs.mavlink_count) &&
-           (rhs.rc_signal_loss == lhs.rc_signal_loss) && 
+           (rhs.valid_rc_setpoint_count == lhs.valid_rc_setpoint_count) && 
            (rhs.sees_desired_control_source == lhs.sees_desired_control_source);
 }
 
@@ -991,7 +991,7 @@ std::ostream& operator<<(std::ostream& str, Telemetry::VehicleStatus const& vehi
     str << "vehicle_status:" << '\n' << "{\n";
     str << "    manual_control_signal_loss: " << vehicle_status.manual_control_signal_loss << '\n';
     str << "    mavlink_count: " << vehicle_status.mavlink_count << '\n';
-    str << "    rc_signal_loss: " << vehicle_status.rc_signal_loss << '\n';
+    str << "    valid_rc_setpoint_count: " << vehicle_status.valid_rc_setpoint_count << '\n';
     str << "    sees_desired_control_source: " << vehicle_status.sees_desired_control_source << '\n';
     str << '}';
     return str;

--- a/src/mavsdk/plugins/telemetry/telemetry.cpp
+++ b/src/mavsdk/plugins/telemetry/telemetry.cpp
@@ -981,7 +981,7 @@ bool operator==(const Telemetry::VehicleStatus& lhs, const Telemetry::VehicleSta
 {
     return (rhs.manual_control_signal_loss == lhs.manual_control_signal_loss) &&
            (rhs.mavlink_count == lhs.mavlink_count) &&
-           (rhs.valid_rc_setpoint_count == lhs.valid_rc_setpoint_count) && 
+           (rhs.rc_count == lhs.rc_count) && 
            (rhs.sees_desired_control_source == lhs.sees_desired_control_source);
 }
 
@@ -991,7 +991,7 @@ std::ostream& operator<<(std::ostream& str, Telemetry::VehicleStatus const& vehi
     str << "vehicle_status:" << '\n' << "{\n";
     str << "    manual_control_signal_loss: " << vehicle_status.manual_control_signal_loss << '\n';
     str << "    mavlink_count: " << vehicle_status.mavlink_count << '\n';
-    str << "    valid_rc_setpoint_count: " << vehicle_status.valid_rc_setpoint_count << '\n';
+    str << "    rc_count: " << vehicle_status.rc_count << '\n';
     str << "    sees_desired_control_source: " << vehicle_status.sees_desired_control_source << '\n';
     str << '}';
     return str;

--- a/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
+++ b/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
@@ -1298,7 +1298,7 @@ void TelemetryImpl::process_sys_status(const mavlink_message_t& message)
         Telemetry::VehicleStatus new_vehicle_status;
     new_vehicle_status.manual_control_signal_loss = sys_status.errors_count1; // No manual control setpoint messages arriving from the desired source
     new_vehicle_status.mavlink_count = sys_status.errors_count2; // Number of (live) Mavlink Joysticks connected
-    new_vehicle_status.rc_count = sys_status.errors_count3; // Number of RC connections providing setpoints (implying RC Connected). Should be < 2.
+    new_vehicle_status.rc_count = sys_status.errors_count3; // Number of (live) RC Controllers connected
     new_vehicle_status.sees_desired_control_source = sys_status.errors_count4; // Indicates desired manual control source, RC (1) or MAVLink (2)
     
     set_vehicle_status(new_vehicle_status);

--- a/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
+++ b/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
@@ -1298,7 +1298,7 @@ void TelemetryImpl::process_sys_status(const mavlink_message_t& message)
         Telemetry::VehicleStatus new_vehicle_status;
     new_vehicle_status.manual_control_signal_loss = sys_status.errors_count1; // No manual control setpoint messages arriving from the desired source
     new_vehicle_status.mavlink_count = sys_status.errors_count2; // Number of (live) Mavlink Joysticks connected
-    new_vehicle_status.rc_signal_loss = sys_status.errors_count3; // No messages from RC TX received
+    new_vehicle_status.valid_rc_setpoint_count = sys_status.errors_count3; // Number of RC connections providing setpoints (implying RC Connected). Should be < 2.
     new_vehicle_status.sees_desired_control_source = sys_status.errors_count4; // Indicates desired manual control source, RC (1) or MAVLink (2)
     
     set_vehicle_status(new_vehicle_status);

--- a/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
+++ b/src/mavsdk/plugins/telemetry/telemetry_impl.cpp
@@ -1298,7 +1298,7 @@ void TelemetryImpl::process_sys_status(const mavlink_message_t& message)
         Telemetry::VehicleStatus new_vehicle_status;
     new_vehicle_status.manual_control_signal_loss = sys_status.errors_count1; // No manual control setpoint messages arriving from the desired source
     new_vehicle_status.mavlink_count = sys_status.errors_count2; // Number of (live) Mavlink Joysticks connected
-    new_vehicle_status.valid_rc_setpoint_count = sys_status.errors_count3; // Number of RC connections providing setpoints (implying RC Connected). Should be < 2.
+    new_vehicle_status.rc_count = sys_status.errors_count3; // Number of RC connections providing setpoints (implying RC Connected). Should be < 2.
     new_vehicle_status.sees_desired_control_source = sys_status.errors_count4; // Indicates desired manual control source, RC (1) or MAVLink (2)
     
     set_vehicle_status(new_vehicle_status);


### PR DESCRIPTION
This PR is interlinked with these:

- https://github.com/SEESAI/Firmware/pull/68
- https://github.com/SEESAI/SeesInterface2/pull/631

For more detail, refer to those.

In short, we are now looking at the number of RC connections providing setpoints (joystick connected) to determine if local RC is connected. We were previously looking at the rc signal_lost flag in PX4, but this does not always work.