### PR TITLE
Bugfix: Connection status only reported as false when the flight controller disconnects

### DIFF
--- a/.github/workflows/sees.yml
+++ b/.github/workflows/sees.yml
@@ -1,0 +1,59 @@
+name: Build Sees Release
+
+on:
+  push:
+    branches:
+    - 'main'
+    tags:
+    - 'v*'
+  pull_request:
+    branches:
+    - '*'
+
+jobs:
+  ubuntu22-superbuild:
+    name: ubuntu-22.04 (mavsdk_server, superbuild)
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - uses: actions/cache@v2
+        id: cache
+        with:
+          path: ./build/release/third_party/install
+          key: ${{ github.job }}-${{ hashFiles('./third_party/**') }}
+      - name: disable superbuild on cache hit
+        if: steps.cache.outputs.cache-hit == 'true'
+        run: echo "superbuild=-DSUPERBUILD=OFF" >> $GITHUB_ENV && echo "cmake_prefix_path=-DCMAKE_PREFIX_PATH=$(pwd)/build/release/third_party/install" >> $GITHUB_ENV
+      - name: install pymavlink dependencies
+        run: sudo apt-get update && sudo apt-get install -y python3-future build-essential cmake
+      - name: configure
+        run: cmake $superbuild $cmake_prefix_path -DCMAKE_BUILD_TYPE=Release -DBUILD_MAVSDK_SERVER=ON -DWERROR=OFF -Bbuild/release -H.
+      - name: build
+        run: cmake --build build/release -j2
+      - name: install
+        run: sudo cmake --build build/release --target install
+      - name: install examples dependencies
+        run: sudo apt-get install -y libsdl2-dev
+      - name: configure examples
+        run: (cd examples && cmake -DCMAKE_BUILD_TYPE=Release -DWERROR=OFF -Bbuild -H.)
+      - name: build examples
+        run: (cd examples && cmake --build build -j2)
+      - name: test
+        run: ./build/release/src/unit_tests_runner
+      - name: test (mavsdk_server)
+        run: ./build/release/src/mavsdk_server/test/unit_tests_mavsdk_server
+      - name: test FTP server
+        run: ./build/release/src/integration_tests/integration_tests_runner --gtest_filter="FtpTest.TestServer"
+      - name: Upload release binaries
+        uses: actions/upload-artifact@v3
+        with:
+          name: mavsdk_server_sees_x86_64
+          path: ./install/bin/mavsdk_server
+      - name: Create Release
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        run: gh release create --verify-tag --draft --generate-notes $TAG install/bin/mavsdk_server
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG:          ${{ github.ref_name }}

--- a/src/mavsdk/core/mavsdk_impl.cpp
+++ b/src/mavsdk/core/mavsdk_impl.cpp
@@ -511,6 +511,9 @@ void MavsdkImpl::notify_on_discover()
         auto temp_callback = _new_system_callback;
         call_user_callback([temp_callback]() { temp_callback(); });
     }
+
+    // Start sending heartbeats now that it's certain there are other systems to receive them.
+    start_sending_heartbeats();
 }
 
 void MavsdkImpl::notify_on_timeout()
@@ -519,6 +522,11 @@ void MavsdkImpl::notify_on_timeout()
     if (_new_system_callback) {
         auto temp_callback = _new_system_callback;
         call_user_callback([temp_callback]() { temp_callback(); });
+    }
+
+    // Only stop sending heartbeats if **all** systems have timed out.
+    if (!is_any_system_connected()) {
+        stop_sending_heartbeats();
     }
 }
 

--- a/src/mavsdk/core/system_impl.cpp
+++ b/src/mavsdk/core/system_impl.cpp
@@ -590,9 +590,6 @@ void SystemImpl::set_connected()
                 _parent.notify_on_discover();
             }
 
-            // Send a heartbeat back immediately.
-            _parent.start_sending_heartbeats();
-
             if (!_always_connected) {
                 register_timeout_handler(
                     [this] { heartbeats_timed_out(); },
@@ -640,8 +637,6 @@ void SystemImpl::set_disconnected()
             _parent.call_user_callback([temp_callback]() { temp_callback(false); });
         }
     }
-
-    _parent.stop_sending_heartbeats();
 
     {
         std::lock_guard<std::mutex> lock(_plugin_impls_mutex);

--- a/src/mavsdk_server/src/core/core_service_impl.h
+++ b/src/mavsdk_server/src/core/core_service_impl.h
@@ -68,11 +68,12 @@ private:
     {
         auto systems = _mavsdk.systems();
 
-        // System at index 0 is always the flight controller.
-        const bool is_connected = systems.size() >= 1 ? systems[0]->is_connected() : false;
+        // Don't publish anything until we have at least one system.
+        if (systems.size() >= 1) {
+            // System at index 0 is always the flight controller.
+            const bool is_connected = systems[0]->is_connected();
 
-        // Send just a single message instead of iterating over all systems.
-        {
+            // Send just a single message instead of iterating over all systems.
             const auto rpc_connection_state_response =
                 createRpcConnectionStateResponse(is_connected);
 

--- a/src/mavsdk_server/src/core/core_service_impl.h
+++ b/src/mavsdk_server/src/core/core_service_impl.h
@@ -68,9 +68,13 @@ private:
     {
         auto systems = _mavsdk.systems();
 
-        for (auto system : systems) {
+        // System at index 0 is always the flight controller.
+        const bool is_connected = systems.size() >= 1 ? systems[0]->is_connected() : false;
+
+        // Send just a single message instead of iterating over all systems.
+        {
             const auto rpc_connection_state_response =
-                createRpcConnectionStateResponse(system->is_connected());
+                createRpcConnectionStateResponse(is_connected);
 
             std::lock_guard<std::mutex> lock(connection_state_mutex);
             writer->Write(rpc_connection_state_response);


### PR DESCRIPTION
There are two fixes in this PR:

1. In the MAVSDK library itself, a `System` object is created for each new sysid discovered. Heartbeats are routed to this object to detect timeouts on a sysid level. If _any_ system times out, heartbeats are disabled in the parent `Mavsdk` instance. The fix in this PR is to only disable heartbeats if _all_ detected sysids timeout.
2. `mavsdk_server` reports connection status as a stream of Boolean values, one per system discovered. However, there is no discriminant, meaning it's impossible to know which Boolean corresponds to which sysid. This becomes a problem if, for example, QGroundControl is launched and then closed, because the last value in the stream will be `false` even with a flight controller actively sending heartbeats. The fix in this PR is to only send the connection status of the flight controller and to ignore all other sysids. Note: this fix is in `mavsdk_server`, so users of the `mavsdk` will not have lost any functionality.