### PR TITLE
Updating transponder with ADSB flags

### DIFF
--- a/src/mavsdk/plugins/transponder/include/plugins/transponder/transponder.h
+++ b/src/mavsdk/plugins/transponder/include/plugins/transponder/transponder.h
@@ -108,6 +108,7 @@ public:
         AdsbEmitterType emitter_type{}; /**< @brief ADSB emitter type. */
         uint32_t squawk{}; /**< @brief Squawk code. */
         uint32_t tslc_s{}; /**< @brief Time Since Last Communication in seconds. */
+        uint16_t flags{};  /**< @brief ADSB flags validity */
     };
 
     /**

--- a/src/mavsdk/plugins/transponder/transponder.cpp
+++ b/src/mavsdk/plugins/transponder/transponder.cpp
@@ -59,7 +59,7 @@ bool operator==(const Transponder::AdsbVehicle& lhs, const Transponder::AdsbVehi
            ((std::isnan(rhs.vertical_velocity_m_s) && std::isnan(lhs.vertical_velocity_m_s)) ||
             rhs.vertical_velocity_m_s == lhs.vertical_velocity_m_s) &&
            (rhs.callsign == lhs.callsign) && (rhs.emitter_type == lhs.emitter_type) &&
-           (rhs.squawk == lhs.squawk) && (rhs.tslc_s == lhs.tslc_s);
+           (rhs.squawk == lhs.squawk) && (rhs.tslc_s == lhs.tslc_s) && (rhs.flags == lhs.flags);
 }
 
 std::ostream& operator<<(std::ostream& str, Transponder::AdsbVehicle const& adsb_vehicle)
@@ -77,6 +77,7 @@ std::ostream& operator<<(std::ostream& str, Transponder::AdsbVehicle const& adsb
     str << "    emitter_type: " << adsb_vehicle.emitter_type << '\n';
     str << "    squawk: " << adsb_vehicle.squawk << '\n';
     str << "    tslc_s: " << adsb_vehicle.tslc_s << '\n';
+    str << "    flags: " << adsb_vehicle.flags << '\n';
     str << '}';
     return str;
 }

--- a/src/mavsdk/plugins/transponder/transponder_impl.cpp
+++ b/src/mavsdk/plugins/transponder/transponder_impl.cpp
@@ -86,6 +86,7 @@ void TransponderImpl::process_transponder(const mavlink_message_t& message)
     adsbVehicle.emitter_type = Transponder::AdsbEmitterType(local_adsb_vehicle.emitter_type);
     adsbVehicle.squawk = local_adsb_vehicle.squawk;
     adsbVehicle.tslc_s = local_adsb_vehicle.tslc;
+    adsbVehicle.flags = local_adsb_vehicle.flags;
 
     set_transponder(adsbVehicle);
 


### PR DESCRIPTION
This PR adds the ADSB flags to be processed in SI2. The corresponding PR for the SI2 ADSB flags is here: https://github.com/SEESAI/SeesInterface2/pull/709.