### PR TITLE
Bugfix: Prevent double callback/promise fulfillment in parameters and…

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,10 +18,10 @@ jobs:
     env:
       NODE_OPTIONS: --max_old_space_size=4096
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: cache
         with:
           path: ./build/third_party/install
@@ -54,7 +54,7 @@ jobs:
     name: ubuntu-20.04 (non-mavsdk_server, non-superbuild)
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: install
@@ -72,10 +72,10 @@ jobs:
     name: ubuntu-20.04 (mavsdk_server, superbuild)
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: cache
         with:
           path: ./build/release/third_party/install
@@ -108,10 +108,10 @@ jobs:
     name: ubuntu-20.04 (mavsdk, hunter)
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: cache
         with:
           path: ~/.hunter
@@ -131,7 +131,7 @@ jobs:
     name: ubuntu-20.04 (proto check)
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: install clang-format
@@ -143,7 +143,7 @@ jobs:
              cd proto/pb_plugins
              pip3 install --user -r requirements.txt
              pip3 install --user -e .
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: cache
         with:
           path: ./build/default/third_party/install
@@ -164,7 +164,7 @@ jobs:
     name: ubuntu-20.04 (check style and docs)
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: install dependencies
@@ -184,7 +184,7 @@ jobs:
       matrix:
         container_name: [ubuntu-18.04, ubuntu-20.04]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: git permission workaround
@@ -222,7 +222,7 @@ jobs:
     name: Ubuntu/Debian packaging (Ubuntu 20.04)
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0
@@ -245,7 +245,7 @@ jobs:
       matrix:
         container_name: [fedora-34, fedora-35]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: git permission workaround
@@ -278,7 +278,7 @@ jobs:
       matrix:
         arch_name: [armv6, armv7, arm64]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: install pymavlink dependencies
@@ -287,7 +287,7 @@ jobs:
         run: tools/generate_mavlink_headers.sh
       - name: setup dockcross
         run: docker run --rm mavsdk/mavsdk-dockcross-linux-${{ matrix.arch_name }}-custom > ./dockcross-linux-${{ matrix.arch_name }}-custom; chmod +x ./dockcross-linux-${{ matrix.arch_name }}-custom
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: cache
         with:
           path: ./build/linux-${{ matrix.arch_name }}/third_party/install
@@ -316,10 +316,10 @@ jobs:
     name: manylinux2010-x64
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: cache
         with:
           path: ./build/manylinux2010-x64/third_party/install
@@ -354,10 +354,10 @@ jobs:
     steps:
       - name: install tools
         run: apk update && apk add build-base cmake git linux-headers perl tar python3 py3-future
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: cache
         with:
           path: ./build/release/third_party/install
@@ -374,7 +374,7 @@ jobs:
       - name: test (mavsdk_server)
         run: ./build/release/src/mavsdk_server/test/unit_tests_mavsdk_server
       - name: Upload as artefact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: mavsdk_server_musl_x86_64
           path: ./install/bin/mavsdk_server
@@ -396,7 +396,7 @@ jobs:
       matrix:
         arch_name: [linux-armv6-musl, linux-armv7l-musl, linux-arm64-musl]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: install pymavlink dependencies
@@ -405,7 +405,7 @@ jobs:
         run: tools/generate_mavlink_headers.sh
       - name: setup dockcross
         run: docker run --rm dockcross/${{ matrix.arch_name }} > ./dockcross-${{ matrix.arch_name }}; chmod +x ./dockcross-${{ matrix.arch_name }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: cache
         with:
           path: ./build/${{ matrix.arch_name }}/third_party/install
@@ -442,7 +442,7 @@ jobs:
           - name: android-x86_64
             arch: x86_64
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: install pymavlink dependencies
@@ -451,7 +451,7 @@ jobs:
         run: tools/generate_mavlink_headers.sh
       - name: setup dockcross
         run: docker run --rm dockcross/${{ matrix.name }} > ./dockcross-${{ matrix.name }}; chmod +x ./dockcross-${{ matrix.name }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: cache
         with:
           path: ./build/${{ matrix.name }}/third_party/install
@@ -486,10 +486,10 @@ jobs:
           - name: macOS-framework
             build-framework: ON
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: cache
         with:
           path: ./build/macos/third_party/install
@@ -513,7 +513,7 @@ jobs:
         run: ./build/macos/src/mavsdk_server/test/unit_tests_mavsdk_server
       - name: Upload framework as artefact
         if: ${{ matrix.build-framework == 'ON' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: mavsdk_server_macos.framework
           path: ./build/macos/src/mavsdk_server/src/mavsdk_server.framework
@@ -541,10 +541,10 @@ jobs:
             platform: SIMULATOR64
             sdk: iphonesimulator
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: cache
         with:
           path: ./build/${{ matrix.name }}/third_party/install
@@ -563,7 +563,7 @@ jobs:
         run: cmake $superbuild $cmake_prefix_path -DENABLE_STRICT_TRY_COMPILE=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$(pwd)/tools/ios.toolchain.cmake -DPLATFORM=${{ matrix.platform }} -DDEPLOYMENT_TARGET=13.0 -DBUILD_MAVSDK_SERVER=ON -DBUILD_SHARED_LIBS=OFF -DWERROR=OFF -Bbuild/${{ matrix.name }} -H.
       - name: build
         run: cmake --build build/${{ matrix.name }} -j2
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: mavsdk_server_${{ matrix.name }}.framework
           path: ./build/${{ matrix.name }}/src/mavsdk_server/src/mavsdk_server.framework
@@ -574,24 +574,24 @@ jobs:
     needs: [macOS, iOS]
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: mavsdk_server_ios.framework
           path: ./build/ios/src/mavsdk_server/src/mavsdk_server.framework
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: mavsdk_server_ios_simulator.framework
           path: ./build/ios_simulator/src/mavsdk_server/src/mavsdk_server.framework
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: mavsdk_server_macos.framework
           path: ./build/macos/src/mavsdk_server/src/mavsdk_server.framework
       - name: Package
         run: bash ./src/mavsdk_server/tools/package_mavsdk_server_framework.bash
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: mavsdk_server.xcframework
           path: ./build/mavsdk_server.xcframework
@@ -619,10 +619,10 @@ jobs:
     name: Windows
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: cache
         with:
           path: ./build/release/third_party/install
@@ -676,7 +676,7 @@ jobs:
         px4_version: [v1.11, v1.12]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: git permission workaround
@@ -710,7 +710,7 @@ jobs:
         apm_version: [copter-4.1.2]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: git permission workaround

--- a/.github/workflows/sees.yml
+++ b/.github/workflows/sees.yml
@@ -15,10 +15,10 @@ jobs:
     name: ubuntu-22.04 (mavsdk_server, superbuild)
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: cache
         with:
           path: ./build/release/third_party/install
@@ -39,7 +39,7 @@ jobs:
       - name: test FTP server
         run: ./build/release/src/integration_tests/integration_tests_runner --gtest_filter="FtpTest.TestServer"
       - name: Upload release binaries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: mavsdk_server_sees_x86_64
           path: ./build/install/bin/mavsdk_server

--- a/src/mavsdk/core/mavlink_command_sender.cpp
+++ b/src/mavsdk/core/mavlink_command_sender.cpp
@@ -295,8 +295,6 @@ void MavlinkCommandSender::receive_timeout(const CommandIdentification& identifi
                          << ").";
                 temp_callback = work->callback;
                 temp_result = {Result::ConnectionError, NAN};
-                _work_queue.erase(it);
-                break;
             }
             --work->retries_to_do;
             _parent.register_timeout_handler(

--- a/src/mavsdk/core/mavlink_command_sender.cpp
+++ b/src/mavsdk/core/mavlink_command_sender.cpp
@@ -295,6 +295,8 @@ void MavlinkCommandSender::receive_timeout(const CommandIdentification& identifi
                          << ").";
                 temp_callback = work->callback;
                 temp_result = {Result::ConnectionError, NAN};
+                _work_queue.erase(it);
+                break;
             }
             --work->retries_to_do;
             _parent.register_timeout_handler(

--- a/src/mavsdk/core/mavlink_parameters.cpp
+++ b/src/mavsdk/core/mavlink_parameters.cpp
@@ -575,9 +575,7 @@ void MAVLinkParameters::get_all_params_async(const GetAllParamsCallback& callbac
 
     if (!_parent.send_message(msg)) {
         LogErr() << "Failed to send param list request!";
-        _all_params_callback = nullptr;
         callback(std::map<std::string, ParamValue>{});
-        return;
     }
 
     _parent.register_timeout_handler(

--- a/src/mavsdk/core/mavlink_parameters.cpp
+++ b/src/mavsdk/core/mavlink_parameters.cpp
@@ -575,7 +575,9 @@ void MAVLinkParameters::get_all_params_async(const GetAllParamsCallback& callbac
 
     if (!_parent.send_message(msg)) {
         LogErr() << "Failed to send param list request!";
+        _all_params_callback = nullptr;
         callback(std::map<std::string, ParamValue>{});
+        return;
     }
 
     _parent.register_timeout_handler(
@@ -1267,6 +1269,7 @@ void MAVLinkParameters::receive_timeout()
         // first check if we are waiting for param list response
         if (_all_params_callback) {
             _all_params_callback({});
+            _all_params_callback = nullptr;
             return;
         }
     }


### PR DESCRIPTION
    Bugfix: Prevent double callback/promise fulfillment in parameters and command sender
    
    Three fixes for cases where a callback wrapping a std::promise could be
    invoked more than once, causing undefined behavior:
    
    - mavlink_parameters: Null _all_params_callback after invocation in
      receive_timeout() to prevent a late-arriving param response from
      calling it a second time.
    - mavlink_parameters: Return early from get_all_params_async() when
      send_message fails, preventing a dangling timeout from re-invoking
      the already-called callback.
    - mavlink_command_sender: On send failure during retry, erase the work
      item and stop rather than continuing to re-register timeouts that
      invoke an already-fulfilled callback.